### PR TITLE
Update dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     rev: stable
     hooks:
     -   id: black
-        language_version: python3.6
+        language_version: python3.7
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.1.0
     hooks:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,54 @@ dataset loaders specialised for video, video frame samplers, and transformations
 
 ## Get started
 
+### Set up an accelerated environment in conda
+
+
+```console
+$ conda env create -f environment.yml -n torchvideo
+$ conda activate torchvideo
+
+# The following steps are taken from
+# https://docs.fast.ai/performance.html#installation
+
+$ conda uninstall -y --force pillow pil jpeg libtiff
+$ pip uninstall -y pillow pil jpeg libtiff
+$ conda install -y -c conda-forge libjpeg-turbo
+$ CFLAGS="${CFLAGS} -mavx2" pip install --upgrade --no-cache-dir --force-reinstall --no-binary :all: --compile pillow-simd
+$ conda install -y jpeg libtiff
+```
+
+NOTE: If the installation of `pillow-simd` fails, you can try installing GCC from
+conda-forge and trying the install again:
+
 ```bash
+$ conda install -y gxx_linux-64
+$ export CXX=x86_64-conda_cos6-linux-gnu-g++
+$ export CC=x86_64-conda_cos6-linux-gnu-gcc
+$ CFLAGS="${CFLAGS} -mavx2" pip install --upgrade --no-cache-dir --force-reinstall --no-binary :all: --compile pillow-simd
+$ conda install -y jpeg libtiff
+```
+
+If you install any new packages, check that `pillow-simd` hasn't be overwritten
+by an alternate `pillow` install by running:
+
+```bash
+$ python -c "from PIL import Image; print(Image.PILLOW_VERSION)"
+```
+
+You should see something like
+
+```
+6.0.0.post0
+```
+
+Pillow doesn't release with `post` suffixes, so if you have `post` in the version
+name, it's likely you have `pillow-simd` installed.
+
+
+### Install torchvideo
+
+```console
 $ pip install git+https://github.com/willprice/torchvideo.git@master
 ```
 

--- a/environment.yml
+++ b/environment.yml
@@ -4,28 +4,27 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - av=6.1.0
-  - ffmpeg==4.0.2
+  - av=6.2.0
+  - ffmpeg
   - lintel=1.0
-  - numpy=1.15.4
-  - cuda90=1.0
-  - pandas==0.23.4
-  - pytorch=0.4.1
-  - python=3.6.8
-  - pip=18.1
-  - torchvision=0.2.1
-  - pre_commit==1.13.0
+  - numpy=1.17.0
+  - pandas==0.25.0
+  - pytorch=1.2.0
+  - python=3.7.3
+  - pip=19.2.1
+  - torchvision=0.4.0
+  - pre_commit==1.18.0
   - pip:
-    - hypothesis==3.84.3
-    - pytest==4.0.2
-    - pytest-cov==2.6.0
-    - pytest-xdist==1.24.0
-    - pyfakefs==3.5.5
+    - hypothesis==4.32.3
+    - pytest==5.0.1
+    - pytest-cov==2.7.1
+    - pytest-xdist==1.29.0
+    - pyfakefs==3.6
     - moviepy==1.0.0
     - gulpio==531.53
-    - sphinx==1.8.3
-    - sphinx_autodoc_typehints==1.6.0
-    - sphinx_rtd_theme==0.4.2
-    - pillow-simd==5.3.0.post0
-    - scipy==1.2.0
-    - mypy==0.650
+    - sphinx==2.1.2
+    - sphinx_autodoc_typehints==1.7.0
+    - sphinx_rtd_theme==0.4.3
+    - pillow-simd==6.0.0.post0
+    - scipy==1.3.1
+    - mypy==0.720

--- a/setup.py
+++ b/setup.py
@@ -25,9 +25,9 @@ REQUIRES_PYTHON = ">=3.5.0"
 REQUIRED = [
     # 'requests', 'maya', 'records',
     "numpy",
-    "torch",
-    "torchvision",
-    "gulpio",
+    "torch>=1.2.0",
+    "torchvision>=0.4.0",
+    "gulpio>=540.66",
 ]
 
 # What packages are optional?

--- a/src/torchvideo/samplers.py
+++ b/src/torchvideo/samplers.py
@@ -1,7 +1,8 @@
 import itertools
 from abc import ABC
 from typing import Union, List, Callable, Tuple, cast
-from numpy.random import randint, np
+import numpy as np
+from numpy.random import randint
 
 from torchvideo.internal.utils import _is_int
 


### PR DESCRIPTION
The build is currently failing due to `torchvision` requiring `pytorch>=1.2.0`. We now depend explicitly on pytorch 1.2.0, we'll swap lintel out for the new video reader bundled in torchvision later 